### PR TITLE
Update tiny_stack_allocator.c

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
       "maintainer": true
     }
   ],
-  "version": "7.1.0",
+  "version": "7.1.1",
   "frameworks": "*",
   "platforms": "*",
   "export": {

--- a/src/tiny_stack_allocator.c
+++ b/src/tiny_stack_allocator.c
@@ -4,6 +4,7 @@
  */
 
 #include <stddef.h>
+#include <stdalign.h>
 #include <stdint.h>
 #include "tiny_stack_allocator.h"
 #include "tiny_utils.h"


### PR DESCRIPTION
I am trying to use this as a library for esphome I think this will fix an error I'm getting

```
../tiny/src/tiny_stack_allocator.c:16:5: error: unknown type name 'max_align_t'
     max_align_t data[max(_size, sizeof(max_align_t)) / sizeof(max_align_t)];          \
     ^~~~~~~~~~~
../tiny/src/tiny_stack_allocator.c:21:1: note: in expansion of macro 'define_worker'
 define_worker(8);
 ^~~~~~~~~~~~~
../tiny/src/tiny_stack_allocator.c:16:40: error: 'max_align_t' undeclared (first use in this function)
     max_align_t data[max(_size, sizeof(max_align_t)) / sizeof(max_align_t)];          \
```